### PR TITLE
Add toolchain file to specify nightly compiler

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -50,6 +50,7 @@ fn conv_type_ident(ident_: &str) -> String {
         "double" => "f64",
         "void" => "c_void",
         "char" => "c_char",
+        "char32_t" => "char",
         "int8_t" => "i8",
         "uint8_t" => "u8",
         "int16_t" => "i16",
@@ -69,6 +70,7 @@ fn conv_type_ident(ident_: &str) -> String {
         "std::string" => "sfStdString",
         "std::vector<std::string>" => "sfStdStringVector",
         "std::vector<sf::VideoMode>" => "sfVideoModeVector",
+        "std::vector<sf::SoundChannel>" => "sfSoundChannelVector",
         _ => ident_,
     })
 }


### PR DESCRIPTION
I didn't want to swap between nightly and stable constantly, and found that there was a way to just set the compiler to nightly for a specific project.

I know this isn't a super official repo, just a help repo, so not so serious, but it makes it easier for any rando to use if need be :).